### PR TITLE
Changes basic commands to use package.json 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,17 @@
+# OS
 .DS_Store
+
+# Logs
+logs
+*.log*
+
+# Compiled binary addons (http://nodejs.org/api/addons.html)
+build/Release
+
+# Dependency directory
+node_modules
+components
+bower_components
+
+# Compile directories
+www/

--- a/README.md
+++ b/README.md
@@ -6,17 +6,24 @@ Powered by [surge](http://surge.sh/).
 
 To check out:
 
-    $ git clone https://github.com/davethegr8/2015.cascadiajs.com.git
-    $ git branch gh-pages origin/gh-pages
-    $ git checkout gh-pages
+```sh
+git clone https://github.com/cascadiajs/2015.cascadiajs.com.git
+git checkout gh-pages
+```
 
 To get running:
 
-    $ ./serve.sh
+```sh
+npm install
+npm start
+# Visit http://localhost:9000
+```
 
 To deploy:
 
-    $ ./deploy.sh
+```sh
+npm run deploy
+```
 
 ## Made By
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,1 +1,0 @@
-surge -p . -d godly-work.surge.sh

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "2015.cascadiajs.com",
+  "version": "0.1.0",
+  "description": "The website for the CascadiaJS 2015 conference",
+  "homepage": "2015.cascadiajs.com",
+  "author": "Dave Poole",
+  "private": true,
+  "repository": "git@github.com:cascadiajs/2015.cascadiajs.com.git",
+  "scripts": {
+    "test": "echo \"Error: no test specified…yet! Pull requests on cascadiajs/2015.cascadiajs are greatly appreciated.\" && exit 1",
+    "start": "harp server",
+    "compile": "harp compile",
+    "deploy": "npm run compile && surge -p ./www -d godly-work.surge.sh"
+  },
+  "devDependencies": {
+    "harp": "^0.14.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "deploy": "npm run compile && surge -p ./www -d godly-work.surge.sh"
   },
   "devDependencies": {
-    "harp": "^0.14.0"
+    "harp": "^0.14.0",
+    "surge": "^0.5.2"
   }
 }

--- a/serve.sh
+++ b/serve.sh
@@ -1,1 +1,0 @@
-harp server


### PR DESCRIPTION
Feel free to take as much or little of this PR as you’d like. I just thought you could change the `serve.sh` and `deploy.sh` scripts to npm run scripts instead.

- Adds `npm start`, `npm run compile`, and `npm run deploy`
- Expands `.gitignore`
- Adds [Harp](http://harpjs.com) and [Surge](http://surge.sh) as `devDependencies` so anyone can `npm install` to contribute
- Updates `README.md` accordingly

Looking forward to the event!