### PR TITLE
Adds alt tags to img tags that were missing them.

### DIFF
--- a/public/_partials/connect.ejs
+++ b/public/_partials/connect.ejs
@@ -32,7 +32,7 @@
 
   <p>Talk about anything CascadiaJS</p>
 
-  <p><a href="https://gitter.im/cascadiajs/2015.cascadiajs.com?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"><img src="https://badges.gitter.im/Chat.svg"/></a></p>
+  <p><a href="https://gitter.im/cascadiajs/2015.cascadiajs.com?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge"><img alt="Connect on Gitter" src="https://badges.gitter.im/Chat.svg"/></a></p>
 
   <p>Share the joy of CascadiaJS with your friends</p>
 

--- a/public/_partials/day/schedule.ejs
+++ b/public/_partials/day/schedule.ejs
@@ -2,7 +2,7 @@
   <div class="row"><div class="col-xs-12">
     <h2 class="first-title">Schedule</h2>
     <p>
-      <img src="/assets/img/sponsors/cmyk.png" style="width: 100px; float: left; margin-right: 1em;"/>
+      <img alt="" src="/assets/img/sponsors/cmyk.png" style="width: 100px; float: left; margin-right: 1em;"/>
       Today's programming provided by CMYK - one way of looking at things
     </p>
   </div></div>
@@ -19,7 +19,7 @@
               Registration -
               <span class="text-lower">coffee provided by
               <a href="#">
-                <img src="/assets/img/sponsors/rgb.png" width="30" style="float: none;"/>
+                <img alt="" src="/assets/img/sponsors/rgb.png" width="30" style="float: none;"/>
                 RGB - another way of looking at things</a></span>
             </td>
             <td class="local"></td>
@@ -27,7 +27,7 @@
           <tr>
             <td class="time">10:00</td>
             <td class="title">
-              <img src="/assets/img/curator/demo-image-02.png" class="profile-image"/>
+              <img alt="" src="/assets/img/curator/demo-image-02.png" class="profile-image"/>
               <a class="speaker" href="#">The Stranger</a>
               <a href="#tite-of-talk">The title of this amazing talk on elements</a>
             </td>
@@ -36,7 +36,7 @@
           <tr>
             <td class="time">11:00</td>
             <td class="title">
-              <img src="/assets/img/curator/demo-image-01.png" class="profile-image"/>
+              <img alt="" src="/assets/img/curator/demo-image-01.png" class="profile-image"/>
               <a class="speaker" href="#">Leslie Knope</a>
               <a href="#tite-of-talk">The title of this amazing talk on elements</a>
             </td>
@@ -50,7 +50,7 @@
           <tr>
             <td class="time">13:45</td>
             <td class="title">
-              <img src="/assets/img/curator/demo-image-04.png" class="profile-image"/>
+              <img alt="" src="/assets/img/curator/demo-image-04.png" class="profile-image"/>
               <a class="speaker" href="#">Bill Murray</a>
               <a href="#tite-of-talk">The title of this amazing talk on elements</a>
             </td>
@@ -60,7 +60,7 @@
           <tr>
             <td class="time">15:00</td>
             <td class="title">
-              <img src="/assets/img/curator/demo-image-05.png" class="profile-image"/>
+              <img alt="" src="/assets/img/curator/demo-image-05.png" class="profile-image"/>
               <a class="speaker" href="#">Astrid Farnsworth</a>
               <a href="#tite-of-talk">The title of this amazing talk on elements</a>
             </td>
@@ -69,7 +69,7 @@
           <tr>
             <td class="time">16:30</td>
             <td class="title">
-              <img src="/assets/img/curator/demo-image-03.png" class="profile-image"/>
+              <img alt="" src="/assets/img/curator/demo-image-03.png" class="profile-image"/>
               <a class="speaker" href="#">Jimi Hendrix</a>
               <a href="#tite-of-talk">The title of this amazing talk on elements</a>
             </td>
@@ -83,7 +83,7 @@
           <tr>
             <td class="time">18:00</td>
             <td class="title">
-              <img src="/assets/img/curator/demo-image-02.png" class="profile-image"/>
+              <img alt="" src="/assets/img/curator/demo-image-02.png" class="profile-image"/>
               <a class="speaker" href="#">The Stranger</a>
               <a href="#tite-of-talk">The title of this amazing talk on elements</a>
             </td>
@@ -176,7 +176,7 @@
 
       <h3>Map</h3>
 
-      <img src="/assets/img/map.png" />
+      <img alt="A map of the conference venue." src="/assets/img/map.png" />
 
     </div>
   </div>

--- a/public/_partials/day/speakers.ejs
+++ b/public/_partials/day/speakers.ejs
@@ -5,53 +5,53 @@
         <h3>Speakers</h3>
 
         <div class="speaker">
-          <img src="/assets/img/curator/demo-image-01.png" class="profile-image"/>
+          <img alt="" src="/assets/img/curator/demo-image-01.png" class="profile-image"/>
           <h4>Leslie Knope</h4>
           <p><a href="#tite-of-talk">The title of this amazing talk on elements</a></p>
         </div>
         <div class="speaker">
-          <img src="/assets/img/curator/demo-image-02.png" class="profile-image"/>
+          <img alt="" src="/assets/img/curator/demo-image-02.png" class="profile-image"/>
           <h4>Leslie Knope</h4>
           <p><a href="#tite-of-talk">The title of this amazing talk on elements</a></p>
         </div>
         <div class="speaker">
-          <img src="/assets/img/curator/demo-image-03.png" class="profile-image"/>
+          <img alt="" src="/assets/img/curator/demo-image-03.png" class="profile-image"/>
           <h4>Leslie Knope</h4>
           <p><a href="#tite-of-talk">The title of this amazing talk on elements</a></p>
         </div>
         <div class="speaker">
-          <img src="/assets/img/curator/demo-image-04.png" class="profile-image"/>
+          <img alt="" src="/assets/img/curator/demo-image-04.png" class="profile-image"/>
           <h4>Leslie Knope</h4>
           <p><a href="#tite-of-talk">The title of this amazing talk on elements</a></p>
         </div>
         <div class="speaker">
-          <img src="/assets/img/curator/demo-image-05.png" class="profile-image"/>
+          <img alt="" src="/assets/img/curator/demo-image-05.png" class="profile-image"/>
           <h4>Leslie Knope</h4>
           <p><a href="#tite-of-talk">The title of this amazing talk on elements</a></p>
         </div>
 
         <div class="speaker">
-          <img src="/assets/img/curator/demo-image-01.png" class="profile-image"/>
+          <img alt="" src="/assets/img/curator/demo-image-01.png" class="profile-image"/>
           <h4>Leslie Knope</h4>
           <p><a href="#tite-of-talk">The title of this amazing talk on elements</a></p>
         </div>
         <div class="speaker">
-          <img src="/assets/img/curator/demo-image-02.png" class="profile-image"/>
+          <img alt="" src="/assets/img/curator/demo-image-02.png" class="profile-image"/>
           <h4>Leslie Knope</h4>
           <p><a href="#tite-of-talk">The title of this amazing talk on elements</a></p>
         </div>
         <div class="speaker">
-          <img src="/assets/img/curator/demo-image-03.png" class="profile-image"/>
+          <img alt="" src="/assets/img/curator/demo-image-03.png" class="profile-image"/>
           <h4>Leslie Knope</h4>
           <p><a href="#tite-of-talk">The title of this amazing talk on elements</a></p>
         </div>
         <div class="speaker">
-          <img src="/assets/img/curator/demo-image-04.png" class="profile-image"/>
+          <img alt="" src="/assets/img/curator/demo-image-04.png" class="profile-image"/>
           <h4>Leslie Knope</h4>
           <p><a href="#tite-of-talk">The title of this amazing talk on elements</a></p>
         </div>
         <div class="speaker">
-          <img src="/assets/img/curator/demo-image-05.png" class="profile-image"/>
+          <img alt="" src="/assets/img/curator/demo-image-05.png" class="profile-image"/>
           <h4>Leslie Knope</h4>
           <p><a href="#tite-of-talk">The title of this amazing talk on elements</a></p>
         </div>

--- a/public/_partials/header-interior.ejs
+++ b/public/_partials/header-interior.ejs
@@ -10,7 +10,7 @@
         </button>
 
         <a class="navbar-brand" href="/">
-          <img src="/assets/img/white-tree.svg" />
+          <img alt="" src="/assets/img/white-tree.svg" />
 
           <p>CASCADIA<span class="thin">FEST <span class="lightblue"><span>2</span><span style="letter-spacing: -.2em;">0</span><span style="letter-spacing: -.1em">1</span><span>5</span></span></span></p>
 

--- a/public/_partials/header.ejs
+++ b/public/_partials/header.ejs
@@ -9,7 +9,7 @@
           <span class="icon-bar"></span>
         </button>
         <a class="navbar-brand" href="/">
-          <img src="/assets/img/aqua-tree.svg" />
+          <img alt="" src="/assets/img/aqua-tree.svg" />
           <p>CASCADIA<span class="thin">FEST 2015</span></p>
         </a>
       </div>

--- a/public/_partials/person.ejs
+++ b/public/_partials/person.ejs
@@ -1,6 +1,6 @@
 <div class="col-xs-12 col-sm-4">
   <% if(typeof avatar !== 'undefined' && avatar) { %>
-  <img src="<%- avatar %>" class="profile-image"/>
+  <img alt="" src="<%- avatar %>" class="profile-image"/>
   <% } %>
   <h4><%- name %></h4>
 

--- a/public/css/index.ejs
+++ b/public/css/index.ejs
@@ -7,7 +7,7 @@
 
             <h1>Cascadia<span class="thin">CSS</span></h1>
             <p class="left lead"><%- description %></p>
-            <img src="/assets/img/cssday/css-hex-icon-ver02.png" class="track-icon" />
+            <img alt="" src="/assets/img/cssday/css-hex-icon-ver02.png" class="track-icon" />
 
         </div>
       </div>

--- a/public/index.ejs
+++ b/public/index.ejs
@@ -11,7 +11,7 @@
         <span class="thin green">Washington State</span>
       </p>
 
-      <img src="/assets/img/white-tree.svg" />
+      <img alt="" src="/assets/img/white-tree.svg" />
     </div>
   </div>
 </div>


### PR DESCRIPTION
There are three main types of changes here.
1. Adding alt text to a few img tags that were missing them and needed to have some sort of descriptive text.
2. Adding `alt=""` to a few img tags that are purely decorative, and so don't need to be read out loud by voice readers.
3. Adding `alt=""` as a low-friction placeholder for templates that will be modified in the future, to serve as a reminder to get some sort of alt text in place.