### PR TITLE
Feature: Add sticky footer

### DIFF
--- a/public/404.ejs
+++ b/public/404.ejs
@@ -1,1 +1,1 @@
-404: page not found
+<div class="site-content">404: page not found</div>

--- a/public/_interior.ejs
+++ b/public/_interior.ejs
@@ -3,10 +3,12 @@
   <%- partial("_partials/head") %>
 
   <body>
-    <%- partial("_partials/header-interior") %>
+    <div class="site">
+      <%- partial("_partials/header-interior") %>
 
-    <%- yield %>
+      <div class="site-content"><%- yield %></div>
 
-    <%- partial("_partials/footer") %>
+      <%- partial("_partials/footer") %>
+    </div>
   </body>
 </html>

--- a/public/_interior.ejs
+++ b/public/_interior.ejs
@@ -3,12 +3,12 @@
   <%- partial("_partials/head") %>
 
   <body>
-    <div class="site">
+    <main>
       <%- partial("_partials/header-interior") %>
 
       <div class="site-content"><%- yield %></div>
 
       <%- partial("_partials/footer") %>
-    </div>
+    </main>
   </body>
 </html>

--- a/public/_layout.ejs
+++ b/public/_layout.ejs
@@ -3,10 +3,12 @@
   <%- partial("_partials/head") %>
 
   <body>
-    <%- partial("_partials/header") %>
+    <div class="site">
+      <%- partial("_partials/header") %>
 
-    <%- yield %>
+      <div class="site-content"><%- yield %></div>
 
-    <%- partial("_partials/footer") %>
+      <%- partial("_partials/footer") %>
+    </div>
   </body>
 </html>

--- a/public/_layout.ejs
+++ b/public/_layout.ejs
@@ -3,12 +3,12 @@
   <%- partial("_partials/head") %>
 
   <body>
-    <div class="site">
+    <main>
       <%- partial("_partials/header") %>
 
       <div class="site-content"><%- yield %></div>
 
       <%- partial("_partials/footer") %>
-    </div>
+    </main>
   </body>
 </html>

--- a/public/assets/css/style.less
+++ b/public/assets/css/style.less
@@ -565,7 +565,7 @@ body {
   height: 100%;
 }
 
-.site {
+main {
   display: flex;
   flex-direction: column;
   height: 100%;

--- a/public/assets/css/style.less
+++ b/public/assets/css/style.less
@@ -558,3 +558,25 @@ table.schedule {
     h4 { margin-bottom: 3px; }
   }
 }
+
+// Sticky Footer
+
+body {
+  height: 100%;
+}
+
+.site {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+header,
+footer {
+  flex: none;
+}
+
+.site-content {
+  flex: 1 0 auto;
+  width: 100%;
+}

--- a/public/news/_layout.ejs
+++ b/public/news/_layout.ejs
@@ -3,7 +3,7 @@
   <%- partial("../_partials/head") %>
 
   <body>
-    <div class="site">
+    <main>
       <%- partial("../_partials/header-interior") %>
 
       <div class="news site-content">
@@ -29,6 +29,6 @@
       </div>
 
       <%- partial("../_partials/footer") %>
-    </div>
+    </main>
   </body>
 </html>

--- a/public/news/_layout.ejs
+++ b/public/news/_layout.ejs
@@ -3,30 +3,32 @@
   <%- partial("../_partials/head") %>
 
   <body>
-    <%- partial("../_partials/header-interior") %>
+    <div class="site">
+      <%- partial("../_partials/header-interior") %>
 
-    <div class="news">
-      <div class="banner background-gray">
-        <div class="container-fluid">
-          <div class="row">
-            <div class="col-xs-12">
-              <h1>CascadiaFest News</h1>
+      <div class="news site-content">
+        <div class="banner background-gray">
+          <div class="container-fluid">
+            <div class="row">
+              <div class="col-xs-12">
+                <h1>CascadiaFest News</h1>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="content">
+          <div class="container-fluid">
+            <div class="row">
+              <div class="col-xs-12">
+                <%- yield %>
+              </div>
             </div>
           </div>
         </div>
       </div>
 
-      <div class="content">
-        <div class="container-fluid">
-          <div class="row">
-            <div class="col-xs-12">
-              <%- yield %>
-            </div>
-          </div>
-        </div>
-      </div>
+      <%- partial("../_partials/footer") %>
     </div>
-
-    <%- partial("../_partials/footer") %>
   </body>
 </html>


### PR DESCRIPTION
This adds a sticky footer with Flexbox. Now, the footer will never float up to the middle of the screen if a page doesn't have much content. (This is particularly relevant for 404 pages.)

Tested on modern browsers including IE10+.

Screenshot:

![screen shot 2015-04-27 at 1 46 34 pm](https://cloud.githubusercontent.com/assets/808159/7357499/05e54950-ece4-11e4-84a2-60c5176cf631.png)

/cc @davethegr8 @zachattack 
