### PR TITLE
Add hacky technique to clone speaker data objects

### DIFF
--- a/public/_partials/footer.ejs
+++ b/public/_partials/footer.ejs
@@ -20,13 +20,15 @@ scripts.forEach(function (script) { %>
 <script>
   $('.js-speaker-group').each(function () {
     var $speakers = $(this).find('.speaker');
-    var $activeSpeaker = $speakers.eq(Math.round(Math.random() * $speakers.length - 1));
-    var $speakerImg = $activeSpeaker.find('.profile-image');
+    var $activeSpeaker = $speakers.eq(Math.floor(Math.random() * $speakers.length - 1));
 
-    $activeSpeaker.removeClass('hidden');
-
-    $speakerImg.attr('src', $speakerImg.data('imgSrc'));
+    $activeSpeaker.css('display', 'block');
   });
+
+  $('.speaker:visible').each(function (index, elem) {
+    var $img = $(elem).find('img');
+    $img.attr('src', $img.data('src'));
+  })
 </script>
 
 <script>

--- a/public/_partials/speaker-feature.ejs
+++ b/public/_partials/speaker-feature.ejs
@@ -1,0 +1,3 @@
+<% for(var i=0;i<speakers.length;i++) { %>
+  <%- partial("../speakers/_partials/poloroid", speakers[i]) %>
+<% } %>

--- a/public/assets/css/style.less
+++ b/public/assets/css/style.less
@@ -309,6 +309,7 @@ header {
   }
 
   .speaker {
+    display: none;
     padding-bottom: 2em;
 
     img {

--- a/public/index.ejs
+++ b/public/index.ejs
@@ -45,19 +45,9 @@
       <div class="col-sm-4 text-center preview-day js-speaker-group" style="background: rebeccapurple; color: white;">
         <h2><a href="/css/">Cascadia<span class="thin">CSS</span></a></h2>
 
-        <%
-          public.speakers._data.index.speakers.css.forEach(function (speaker) {
-
-            var previewSpeaker = JSON.parse(JSON.stringify(speaker));
-
-            previewSpeaker.classname = "hidden";
-            previewSpeaker.lazyImg = true;
-
-            %>
-              <%- partial("speakers/_partials/poloroid", previewSpeaker) %>
-            <%
-          });
-        %>
+        <%- partial('_partials/speaker-feature', {
+          "speakers": public.speakers._data.index.speakers.css
+        }) %>
 
         <p class="see-all-speakers">
           <a href="/css/#speakers">
@@ -69,19 +59,9 @@
       <div class="col-sm-4 text-center preview-day js-speaker-group" style="background: #60713e; color: white;">
         <h2><a href="/browser/">Cascadia<span class="thin">JS</span>: Browser Day</a></h2>
 
-        <%
-          public.speakers._data.index.speakers.browser.forEach(function (speaker) {
-
-            var previewSpeaker = JSON.parse(JSON.stringify(speaker));
-
-            previewSpeaker.classname = "hidden";
-            previewSpeaker.lazyImg = true;
-
-            %>
-              <%- partial("speakers/_partials/poloroid", previewSpeaker) %>
-            <%
-          });
-        %>
+        <%- partial('_partials/speaker-feature', {
+          "speakers": public.speakers._data.index.speakers.browser
+        }) %>
 
         <p class="see-all-speakers">
           <a href="/browser/#speakers">
@@ -93,19 +73,9 @@
       <div class="col-sm-4 text-center preview-day js-speaker-group" style="background: #eb7e2f; color: white;">
         <h2><a href="/server/">Cascadia<span class="thin">JS</span>: Server Day</a></h2>
 
-        <%
-          public.speakers._data.index.speakers.server.forEach(function (speaker) {
-
-            var previewSpeaker = JSON.parse(JSON.stringify(speaker));
-
-            previewSpeaker.classname = "hidden";
-            previewSpeaker.lazyImg = true;
-
-            %>
-              <%- partial("speakers/_partials/poloroid", previewSpeaker) %>
-            <%
-          });
-        %>
+        <%- partial('_partials/speaker-feature', {
+          "speakers": public.speakers._data.index.speakers.server
+        }) %>
 
         <p class="see-all-speakers">
           <a href="/server/#speakers">

--- a/public/index.ejs
+++ b/public/index.ejs
@@ -48,11 +48,13 @@
         <%
           public.speakers._data.index.speakers.css.forEach(function (speaker) {
 
-            speaker.classname = "hidden";
-            speaker.lazyImg = true;
+            var previewSpeaker = JSON.parse(JSON.stringify(speaker));
+
+            previewSpeaker.classname = "hidden";
+            previewSpeaker.lazyImg = true;
 
             %>
-              <%- partial("speakers/_partials/poloroid", speaker) %>
+              <%- partial("speakers/_partials/poloroid", previewSpeaker) %>
             <%
           });
         %>
@@ -70,11 +72,13 @@
         <%
           public.speakers._data.index.speakers.browser.forEach(function (speaker) {
 
-            speaker.classname = "hidden";
-            speaker.lazyImg = true;
+            var previewSpeaker = JSON.parse(JSON.stringify(speaker));
+
+            previewSpeaker.classname = "hidden";
+            previewSpeaker.lazyImg = true;
 
             %>
-              <%- partial("speakers/_partials/poloroid", speaker) %>
+              <%- partial("speakers/_partials/poloroid", previewSpeaker) %>
             <%
           });
         %>
@@ -92,11 +96,13 @@
         <%
           public.speakers._data.index.speakers.server.forEach(function (speaker) {
 
-            speaker.classname = "hidden";
-            speaker.lazyImg = true;
+            var previewSpeaker = JSON.parse(JSON.stringify(speaker));
+
+            previewSpeaker.classname = "hidden";
+            previewSpeaker.lazyImg = true;
 
             %>
-              <%- partial("speakers/_partials/poloroid", speaker) %>
+              <%- partial("speakers/_partials/poloroid", previewSpeaker) %>
             <%
           });
         %>

--- a/public/speakers/_partials/poloroid.ejs
+++ b/public/speakers/_partials/poloroid.ejs
@@ -1,12 +1,8 @@
 
 <div class="clearfix poloroid speaker <%- typeof classname != 'undefined' ? classname : '' %>">
   <div class="inner">
-    <% if(typeof avatar !== "undefined") {
-      if (typeof lazyImg !== 'undefined' && lazyImg === true) { %>
-        <img alt="" src="" data-img-src="<%- avatar %>" class="profile-image" />
-      <% } else { %>
-        <img alt="" src="<%- avatar %>" class="profile-image"/>
-      <% } %>
+    <% if(typeof avatar !== "undefined") { %>
+      <img alt="" src="" data-src="<%- avatar %>" class="profile-image" />
     <% } %>
 
     <h4><%- name %></h4>

--- a/public/speakers/_partials/poloroid.ejs
+++ b/public/speakers/_partials/poloroid.ejs
@@ -2,7 +2,7 @@
 <div class="clearfix poloroid speaker <%- typeof classname != 'undefined' ? classname : '' %>">
   <div class="inner">
     <% if(typeof avatar !== "undefined") {
-      if (typeof lazyImg != 'undefined' && lazyImg === true) { %>
+      if (typeof lazyImg !== 'undefined' && lazyImg === true) { %>
         <img alt="" src="" data-img-src="<%- avatar %>" class="profile-image" />
       <% } else { %>
         <img alt="" src="<%- avatar %>" class="profile-image"/>


### PR DESCRIPTION
This adds an ugly JSON stringify + parse solution to clone the speaker data because the homepage template was able to modify data used elsewhere, which is cool.

Fixes an issue where speaker images didn't load on pages other than the homepage.

/cc @davethegr8 