### PR TITLE
Chore: Fix CascadiaCSS "track" copy

### DIFF
--- a/public/css/_data.json
+++ b/public/css/_data.json
@@ -2,7 +2,7 @@
   "index": {
     "title": "CascadiaCSS | CascadiaFEST 2015",
     "color": "#663399",
-    "description": "A CSS conference track for the Pacific Northwest.<br> July 8th, 2015 at Semiahmoo Resort in Washington.",
+    "description": "A CSS conference for the Pacific Northwest.<br> July 8th, 2015 at Semiahmoo Resort in Washington.",
     "sponsorConfig": {
       "show": "css",
       "description": "These amazing companies have stepped up to help bring CascadiaCSS to you",


### PR DESCRIPTION
Looks like there was some confusion about the CascadiaCSS branding a while back and this didn't get reverted along with the other changes made at the time.

/cc @davethegr8 