### PR TITLE
Bug: Fix Alan's snippet on the news page

### DIFF
--- a/website/public/news/_data.json
+++ b/website/public/news/_data.json
@@ -3,7 +3,7 @@
     "layout": "_layout_speaker",
     "day": "css",
     "speakerID": "3",
-    "abstract": "ADD ME."
+    "abstract": "Alan Mooiman is a front-end developer currently residing in New York, but soon to be a bonafide Cascadian in Portland, OR. He'll be speaking at CascadiaCSS about how the future of CSS will let us write CSS without being dependent on preprocessors."
   },
   "intro-rachel-nabors": {
     "layout": "_layout_speaker",


### PR DESCRIPTION
Forgot to add in a snippet of Alan's introducing post for the news page.

/cc @davethegr8 